### PR TITLE
FEAT : BDBD-371 Github PR 상태에 따른 Issue Transition 추가

### DIFF
--- a/.github/workflows/issueTransition.yml
+++ b/.github/workflows/issueTransition.yml
@@ -1,0 +1,38 @@
+name: issueTransitionForPR
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+    types: [ opened ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: JiraLogin
+        uses: atlassian/gajira-login@master
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+      - name: Find in commit messages
+        uses: atlassian/gajira-find-issue-key@master
+        id: jira-ticket
+        with:
+          from: commits
+      - name: Transition issue to review
+        if: $ {{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'pull_request' }}
+        uses: atlassian/gajira-transition@master
+        with:
+          issue: ${{ steps.jira-ticket.outputs.issue }}
+          transition: "리뷰 대기"
+      - name: Transition issue to complete
+        if: $ {{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'push' }}
+        uses: atlassian/gajira-transition@master
+        with:
+          issue: ${{ steps.jira-ticket.outputs.issue }}
+          transition: "완료"

--- a/.github/workflows/issueTransition.yml
+++ b/.github/workflows/issueTransition.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           from: commits
       - name: Transition issue to review
-        if: $ {{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'pull_request' }}
+        if: ${{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'pull_request' }}
         uses: atlassian/gajira-transition@master
         with:
           issue: ${{ steps.jira-ticket.outputs.issue }}
           transition: "리뷰 대기"
       - name: Transition issue to complete
-        if: $ {{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'push' }}
+        if: ${{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'push' }}
         uses: atlassian/gajira-transition@master
         with:
           issue: ${{ steps.jira-ticket.outputs.issue }}

--- a/.github/workflows/issueTransition.yml
+++ b/.github/workflows/issueTransition.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ develop ]
     types: [ opened ]
-  pull_request_target:
 
 jobs:
   build:

--- a/.github/workflows/issueTransition.yml
+++ b/.github/workflows/issueTransition.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ develop ]
     types: [ opened ]
+  pull_request_target:
 
 jobs:
   build:
@@ -23,7 +24,7 @@ jobs:
         uses: atlassian/gajira-find-issue-key@master
         id: jira-ticket
         with:
-          from: commits
+          string: ${{ github.event.ref }}
       - name: Transition issue to review
         if: ${{ steps.jira-ticket.outputs.issue != '' && github.event_name == 'pull_request' }}
         uses: atlassian/gajira-transition@master


### PR DESCRIPTION
### 개요
* Github PR 상태에 따른 Issue Transition 추가

### 변경사항
* develop에 pr을 날리면 해당 이슈가 리뷰 대기로 넘어가는 기능 추가
* develop로 머지하면 해당 이슈가 완료로 넘어가는 기능 추가

### 관련 지라 및 위키 링크
* [BDBD-371](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-371)

### 리뷰어에게 하고 싶은 말
* PR을 날려야 테스트가 가능해서 곧 터질 수 있음