### PR TITLE
FEAT : BDBD-438 Divider 교체

### DIFF
--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -110,11 +110,10 @@
                 android:textSize="@dimen/small_text_button_size"
                 tools:ignore="TextContrastCheck" />
 
-            <View
+            <com.google.android.material.divider.MaterialDivider
                 android:layout_width="1dp"
                 android:layout_height="match_parent"
-                android:layout_marginHorizontal="4dp"
-                android:background="?android:attr/listDivider" />
+                android:layout_marginHorizontal="4dp" />
 
             <TextView
                 android:id="@+id/textview_login_find_password"
@@ -125,11 +124,10 @@
                 android:textSize="@dimen/small_text_button_size"
                 tools:ignore="TextContrastCheck" />
 
-            <View
+            <com.google.android.material.divider.MaterialDivider
                 android:layout_width="1dp"
                 android:layout_height="match_parent"
-                android:layout_marginHorizontal="4dp"
-                android:background="?android:attr/listDivider" />
+                android:layout_marginHorizontal="4dp" />
 
             <TextView
                 android:id="@+id/textview_login_registration"

--- a/app/src/main/res/layout/fragment_product_list.xml
+++ b/app/src/main/res/layout/fragment_product_list.xml
@@ -25,16 +25,14 @@
             app:layout_constraintTop_toTopOf="parent"
             app:menu="@menu/toolbar_product_list_menu"/>
 
-        <View
+        <com.google.android.material.divider.MaterialDivider
             android:id="@+id/divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="?android:attr/listDivider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="@+id/toolbar_product_list"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/toolbar_product_list" />
-
 
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipe_product_list"

--- a/app/src/main/res/layout/include_product_detail_bid_info.xml
+++ b/app/src/main/res/layout/include_product_detail_bid_info.xml
@@ -37,11 +37,9 @@
                     android:gravity="center"
                     android:text="입찰 순위" />
 
-                <View
-                    android:id="@+id/view"
+                <com.google.android.material.divider.MaterialDivider
                     android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="?android:attr/listDivider" />
+                    android:layout_height="wrap_content" />
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_bid_info"

--- a/app/src/main/res/layout/include_product_detail_bidding.xml
+++ b/app/src/main/res/layout/include_product_detail_bidding.xml
@@ -75,12 +75,11 @@
                     app:layout_constraintTop_toBottomOf="@+id/textview_minimum_bid_value"
                     tools:text="500원" />
 
-                <View
+                <com.google.android.material.divider.MaterialDivider
                     android:id="@+id/divider"
                     android:layout_width="0dp"
-                    android:layout_height="1dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:background="?android:attr/listDivider"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/textview_tick" />

--- a/app/src/main/res/layout/include_product_detail_seller.xml
+++ b/app/src/main/res/layout/include_product_detail_seller.xml
@@ -4,11 +4,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <View
+    <com.google.android.material.divider.MaterialDivider
         android:id="@+id/upper_divider"
         android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -62,11 +61,10 @@
 
     </androidx.cardview.widget.CardView>
 
-    <View
+    <com.google.android.material.divider.MaterialDivider
         android:id="@+id/bottom_divider"
         android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />

--- a/app/src/main/res/layout/recycler_bid_info.xml
+++ b/app/src/main/res/layout/recycler_bid_info.xml
@@ -34,10 +34,8 @@
             tools:text="1,000,000,000,000" />
     </LinearLayout>
 
-    <View
-        android:id="@+id/view"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="0dp"
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar_product_search.xml
+++ b/app/src/main/res/layout/toolbar_product_search.xml
@@ -47,11 +47,9 @@
                 app:layout_constraintStart_toEndOf="@+id/button_toolbar_back"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <View
-                android:id="@+id/divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="?android:attr/listDivider"
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/edittext_toolbar_search" />


### PR DESCRIPTION
### 개요
* View를 짜부시켜서 사용했던 구분선을 MaterialDivider로 교체

### 변경사항
* 회원가입 관련 xml을 제외한 모든 xml 파일의 구분선을 MaterialDivider로 교체

### 관련 지라 및 위키 링크
* [샌박 링크](https://github.com/FakeDevelopers/BidderBidder_AOS/releases/tag/2022-09-05-10-34)
  * 샌박이 있긴한데 진짜 태그만 갈아끼운 작업이라 코드만 봐도 무방합니다. 
* [BDBD-438](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-438)

### 리뷰어에게 하고 싶은 말
* 기존 구분선 보다 색이 살짝 연합니다. (MaterialDivider의 기본 색상 사용)
  * 제가 이전에 임의로 정해논 색상보다 드자이너들이 머리를 맞대서 결정한 색상이 더 좋지 않겠읍니까