### PR TITLE
FEAT : BDBD-475 ApiErrorHandler Class 수정 및 함수 적용

### DIFF
--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/CLViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/CLViewModel.kt
@@ -3,6 +3,7 @@ package com.fakedevelopers.bidderbidder.ui.chat.channel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.bidderbidder.api.repository.ChatRepository
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.MutableEventFlow
 import com.fakedevelopers.bidderbidder.ui.util.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,7 +26,13 @@ class CLViewModel @Inject constructor(
     fun requestStreamUserToken() {
         val id = streamUserId.value.toLongOrNull() ?: return
         viewModelScope.launch {
-            _streamUserTokenEvent.emit(repository.getStreamUserToken(id))
+            repository.getStreamUserToken(id).let {
+                if (it.isSuccessful) {
+                    _streamUserTokenEvent.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/CLViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/CLViewModel.kt
@@ -30,7 +30,7 @@ class CLViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     _streamUserTokenEvent.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/ChannelListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/ChannelListFragment.kt
@@ -72,7 +72,7 @@ class ChannelListFragment : Fragment() {
                         initUser(it.body().toString())
                         viewModel.setToken(it.body().toString())
                     } else {
-                        ApiErrorHandler.handleError(it.errorBody())
+                        ApiErrorHandler.printErrorMessage(it.errorBody())
                     }
                 }
             }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/ChannelListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/chat/channel/ChannelListFragment.kt
@@ -72,7 +72,7 @@ class ChannelListFragment : Fragment() {
                         initUser(it.body().toString())
                         viewModel.setToken(it.body().toString())
                     } else {
-                        ApiErrorHandler.print(it.errorBody())
+                        ApiErrorHandler.handleError(it.errorBody())
                     }
                 }
             }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.fakedevelopers.bidderbidder.ui.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.bidderbidder.api.repository.UserLoginRepository
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +24,13 @@ class LoginViewModel @Inject constructor(private val repository: UserLoginReposi
 
     fun loginRequest() {
         viewModelScope.launch {
-            _loginResponse.emit(repository.postLogin(email.value, passwd.value))
+            repository.postLogin(email.value, passwd.value).let {
+                if (it.isSuccessful) {
+                    _loginResponse.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginViewModel.kt
@@ -28,7 +28,7 @@ class LoginViewModel @Inject constructor(private val repository: UserLoginReposi
                 if (it.isSuccessful) {
                     _loginResponse.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeViewModel.kt
@@ -31,7 +31,7 @@ class LoginTypeViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     _signinGoogleResponse.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeViewModel.kt
@@ -3,6 +3,7 @@ package com.fakedevelopers.bidderbidder.ui.loginType
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.bidderbidder.api.repository.SigninGoogleRepository
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.HttpRequestExtensions.Companion.BEARER_TOKEN_PREFIX
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
 import com.google.firebase.auth.FirebaseAuth
@@ -26,7 +27,13 @@ class LoginTypeViewModel @Inject constructor(
 
     private fun signinGoogleRequest(token: String) {
         viewModelScope.launch {
-            _signinGoogleResponse.emit(repository.postSigninGoogle(token))
+            repository.postSigninGoogle(token).let {
+                if (it.isSuccessful) {
+                    _signinGoogleResponse.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailFragment.kt
@@ -69,7 +69,7 @@ class ProductDetailFragment : Fragment() {
                     if (it.isSuccessful) {
                         viewModel.initProductDetail(it.body())
                     } else {
-                        ApiErrorHandler.handleError(it.errorBody())
+                        ApiErrorHandler.printErrorMessage(it.errorBody())
                     }
                 }
             }
@@ -87,7 +87,7 @@ class ProductDetailFragment : Fragment() {
                     } else {
                         // 실패했으면 입찰가 조작을 다시 활성화
                         viewModel.setBiddingEnabled(true)
-                        ApiErrorHandler.handleError(it.errorBody())
+                        ApiErrorHandler.printErrorMessage(it.errorBody())
                     }
                 }
             }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailFragment.kt
@@ -69,7 +69,7 @@ class ProductDetailFragment : Fragment() {
                     if (it.isSuccessful) {
                         viewModel.initProductDetail(it.body())
                     } else {
-                        ApiErrorHandler.print(it.errorBody())
+                        ApiErrorHandler.handleError(it.errorBody())
                     }
                 }
             }
@@ -87,7 +87,7 @@ class ProductDetailFragment : Fragment() {
                     } else {
                         // 실패했으면 입찰가 조작을 다시 활성화
                         viewModel.setBiddingEnabled(true)
-                        ApiErrorHandler.print(it.errorBody())
+                        ApiErrorHandler.handleError(it.errorBody())
                     }
                 }
             }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailViewModel.kt
@@ -100,7 +100,7 @@ class ProductDetailViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     _productDetailResponse.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }
@@ -277,7 +277,7 @@ class ProductDetailViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     _productBidResponse.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productDetail/ProductDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.bidderbidder.api.data.Constants.Companion.dec
 import com.fakedevelopers.bidderbidder.api.repository.ProductDetailRepository
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.ExpirationTimerTask
 import com.fakedevelopers.bidderbidder.ui.util.MutableEventFlow
 import com.fakedevelopers.bidderbidder.ui.util.asEventFlow
@@ -95,7 +96,13 @@ class ProductDetailViewModel @Inject constructor(
     fun productDetailRequest(productId: Long) {
         this.productId = productId
         viewModelScope.launch {
-            _productDetailResponse.emit(repository.getProductDetail(productId))
+            repository.getProductDetail(productId).let {
+                if (it.isSuccessful) {
+                    _productDetailResponse.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 
@@ -266,7 +273,13 @@ class ProductDetailViewModel @Inject constructor(
         // 입찰가 조작을 막고 api 요청
         setBiddingEnabled(false)
         viewModelScope.launch {
-            _productBidResponse.emit(repository.postProductBid(productId, requestUserId, requestBid))
+            repository.postProductBid(productId, requestUserId, requestBid).let {
+                if (it.isSuccessful) {
+                    _productBidResponse.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListViewModel.kt
@@ -83,7 +83,7 @@ class ProductListViewModel @Inject constructor(
                         isLastProduct.emit(true)
                     }
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
             setLoadingState(false)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListViewModel.kt
@@ -3,9 +3,9 @@ package com.fakedevelopers.bidderbidder.ui.productList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.bidderbidder.api.repository.ProductListRepository
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.MutableEventFlow
 import com.fakedevelopers.bidderbidder.ui.util.asEventFlow
-import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -83,7 +83,7 @@ class ProductListViewModel @Inject constructor(
                         isLastProduct.emit(true)
                     }
                 } else {
-                    Logger.e(it.errorBody().toString())
+                    ApiErrorHandler.handleError(it.errorBody())
                 }
             }
             setLoadingState(false)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
@@ -129,7 +129,7 @@ class ProductRegistrationViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     _productRegistrationResponse.emit(it)
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }
@@ -141,7 +141,7 @@ class ProductRegistrationViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     it.body()?.let { responseBody -> _productCategory.emit(responseBody) }
                 } else {
-                    ApiErrorHandler.handleError(it.errorBody())
+                    ApiErrorHandler.printErrorMessage(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
@@ -125,7 +125,13 @@ class ProductRegistrationViewModel @Inject constructor(
             map["representPicture"] = "0".toPlainRequestBody()
             map["tick"] = tick.value.replace(",", "").toPlainRequestBody()
             map["category"] = categoryID.toString().toPlainRequestBody()
-            _productRegistrationResponse.emit(repository.postProductRegistration(imageList, map))
+            repository.postProductRegistration(imageList, map).let {
+                if (it.isSuccessful) {
+                    _productRegistrationResponse.emit(it)
+                } else {
+                    ApiErrorHandler.handleError(it.errorBody())
+                }
+            }
         }
     }
 
@@ -135,7 +141,7 @@ class ProductRegistrationViewModel @Inject constructor(
                 if (it.isSuccessful) {
                     it.body()?.let { responseBody -> _productCategory.emit(responseBody) }
                 } else {
-                    ApiErrorHandler.print(it.errorBody())
+                    ApiErrorHandler.handleError(it.errorBody())
                 }
             }
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ApiErrorHandler.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ApiErrorHandler.kt
@@ -6,7 +6,7 @@ import io.sentry.Sentry
 import okhttp3.ResponseBody
 
 object ApiErrorHandler {
-    fun print(errorBody: ResponseBody?) {
+    fun handleError(errorBody: ResponseBody?) {
         if (errorBody == null) {
             return
         }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ApiErrorHandler.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ApiErrorHandler.kt
@@ -6,7 +6,7 @@ import io.sentry.Sentry
 import okhttp3.ResponseBody
 
 object ApiErrorHandler {
-    fun handleError(errorBody: ResponseBody?) {
+    fun printErrorMessage(errorBody: ResponseBody?) {
         if (errorBody == null) {
             return
         }


### PR DESCRIPTION
### 개요
* API 요청 실패 처리 함수 적용

### 변경사항
* ApiErrorHandler의 print에서 handleError로 변경
* API 요청 하는 곳에서 handleError 함수 모두 적용

### 관련 지라 및 위키 링크
* [BDBD-475](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-475)
* [활용한 함수명 출처](https://angular.kr/api/core/ErrorHandler#handleError)

### 리뷰어에게 하고 싶은 말
* 기존에 예시로 적용되었던 productBidResponse API에러 처리 방식과 통일감 있게 처리하였습니다.