### PR TITLE
FIX : BDBD-480 글쓰기 화면에서 화면 전환 시 발생하는 exception 수정

### DIFF
--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/repository/ProductCategoryRepository.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/repository/ProductCategoryRepository.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class ProductCategoryRepository @Inject constructor(
     private val service: ProductCategoryService
 ) {
-    suspend fun getProdectCategory(): Response<List<ProductCategoryDto>> {
+    suspend fun getProductCategory(): Response<List<ProductCategoryDto>> {
         return service.getProductRegistrationCategory()
     }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
@@ -39,9 +39,9 @@ import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.C
 import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.Companion.MAX_PRICE_LENGTH
 import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.Companion.MAX_TICK_LENGTH
 import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumImageUtils
+import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
 import com.fakedevelopers.bidderbidder.ui.util.KeyboardVisibilityUtils
-import com.orhanobut.logger.Logger
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.collectLatest
@@ -101,7 +101,6 @@ class ProductRegistrationFragment : Fragment() {
                     .attachToRecyclerView(binding.recyclerProductRegistration)
             }
         }
-        viewModel.requestProductCategory()
         initListener()
         initCollector()
     }
@@ -147,15 +146,12 @@ class ProductRegistrationFragment : Fragment() {
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     s.toString().replace(IS_NOT_NUMBER.toRegex(), "").toIntOrNull()?.let {
                         if (it > MAX_EXPIRATION_TIME) {
-                            binding.edittextProductRegistrationExpiration.apply {
-                                setText(MAX_EXPIRATION_TIME.toString())
-                                setSelection(text.length)
-                            }
+                            setText(MAX_EXPIRATION_TIME.toString())
+                            setSelection(text.length)
                         } else if (it.toString().length != text.length) {
                             setText(it.toString())
                             setSelection(text.length)
                         }
-                        it
                     }
                 }
 
@@ -236,7 +232,6 @@ class ProductRegistrationFragment : Fragment() {
                         findNavController().navigate(R.id.action_productRegistrationFragment_to_productListFragment)
                     } else {
                         binding.includeProductRegistrationToolbar.buttonToolbarRegistration.isEnabled = true
-                        Logger.t("myImage").e(it.errorBody().toString())
                         Toast.makeText(requireContext(), "글쓰기에 실패했어요~", Toast.LENGTH_SHORT).show()
                     }
                 }
@@ -274,10 +269,15 @@ class ProductRegistrationFragment : Fragment() {
             }
         }
         lifecycleScope.launch {
-            viewModel.productCategory.collect {
-                if (it.isNotEmpty()) {
-                    viewModel.setCategoryList(it)
-                    setCategory(viewModel.category)
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.categoryEvent.collectLatest { result ->
+                    if (result.isSuccessful) {
+                        val category = result.body() ?: return@collectLatest
+                        viewModel.setProductCategory(category)
+                        setCategory(category)
+                    } else {
+                        ApiErrorHandler.printErrorMessage(result.errorBody())
+                    }
                 }
             }
         }
@@ -285,16 +285,11 @@ class ProductRegistrationFragment : Fragment() {
 
     // 희망가 <= 최소 입찰가 인지 검사
     private fun checkPriceCondition(): Boolean {
-        runCatching {
-            Pair(
-                viewModel.openingBid.value.replace(IS_NOT_NUMBER.toRegex(), "").toLong(),
-                viewModel.hopePrice.value.replace(IS_NOT_NUMBER.toRegex(), "").toLong()
-            )
-        }.onSuccess {
-            if (it.first >= it.second) {
-                Toast.makeText(requireContext(), "최소 입찰가는 희망 가격보다 작아야 합니다.", Toast.LENGTH_SHORT).show()
-                return false
-            }
+        val openingBid = viewModel.openingBid.value.replace(IS_NOT_NUMBER.toRegex(), "").toLongOrNull() ?: return false
+        val hopePrice = viewModel.hopePrice.value.replace(IS_NOT_NUMBER.toRegex(), "").toLongOrNull() ?: return false
+        if (openingBid >= hopePrice) {
+            Toast.makeText(requireContext(), "최소 입찰가는 희망 가격보다 작아야 합니다.", Toast.LENGTH_SHORT).show()
+            return false
         }
         return true
     }
@@ -308,7 +303,7 @@ class ProductRegistrationFragment : Fragment() {
                     getMultipart(uri, editedBitmap)?.let { multiPart -> list.add(multiPart) }
                 }
             }
-            return@async list.toList()
+            list.toList()
         }
         return result.await()
     }
@@ -347,14 +342,12 @@ class ProductRegistrationFragment : Fragment() {
         }
     }
 
-    private fun setCategory(category: List<String>) {
-        val arrayAdapter = object : ArrayAdapter<String>(
+    private fun setCategory(category: List<ProductCategoryDto>) {
+        val arrayAdapter = ArrayAdapter(
             requireContext(),
             R.layout.spinner_product_registration,
-            category
-        ) {
-            // Do nothing
-        }
+            category.map { it.categoryName }
+        )
         binding.spinnerProductRegistrationCategory.apply {
             adapter = arrayAdapter
             setSelection(arrayAdapter.count - 1)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
@@ -272,14 +272,21 @@ class ProductRegistrationFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.categoryEvent.collectLatest { result ->
                     if (result.isSuccessful) {
-                        val category = result.body() ?: return@collectLatest
-                        viewModel.setProductCategory(category)
-                        setCategory(category)
+                        handleCategoryResult(result.body())
                     } else {
                         ApiErrorHandler.printErrorMessage(result.errorBody())
                     }
                 }
             }
+        }
+    }
+
+    private fun handleCategoryResult(body: List<ProductCategoryDto>?) {
+        body?.let { category ->
+            viewModel.setProductCategory(category)
+            setCategory(category)
+        } ?: run {
+            ApiErrorHandler.printMessage("카테고리 api의 body가 비었어")
         }
     }
 


### PR DESCRIPTION
### 개요
* 글쓰기 화면에서 화면 전환 시 발생하는 exception 수정

### 변경사항
* 카테고리 api 요청을 받는 변수를 EventFlow로 변경
* EventFlow를 collect 하는 부분을 repeatOnLifecycle로 감쌌습니다.
* 지난날의 과오들을 일부 최적화 했습니다.
  * 구조를 엎지않는 선에서 이거 왜이랬지 하는 부분들을 고쳤습니다.

### 관련 지라 및 위키 링크
* [BDBD-480](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-480)

### 리뷰어에게 하고 싶은 말
* 카테고리를 받아오지 않는 상황에서 화면 전환을 시도하면 exception이 발생합니다.  
  * 화면을 전환해서 productRegistration Fragment는 사라졌지만 카테고리를 가져오는 코루틴 작업이 cancel 되지 않았고 이미 사라진 뷰에 카테고리를 박으려고 했던 것이 원인입니다.  
  * 그런데 수정 전 코드도 productRegistration Fragment가 사라지면 코루틴 작업도 같이 취소되는 코드인데 왜 취소가 안됐는지 모르겠군요. 더 공부해 봐야겠어요

서버가 느린게 버그를 잡는데 많은 도움이 되네용 ㅎㅎ.. 