### PR TITLE
FEAT : BDBD-482 사진 선택 동작 최적화

### DIFF
--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/DragAndDropCallback.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/DragAndDropCallback.kt
@@ -19,7 +19,7 @@ class DragAndDropCallback(
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-        adapter.onItemDragMove(viewHolder.adapterPosition, target.adapterPosition)
+        adapter.onItemDragMove(viewHolder.absoluteAdapterPosition, target.absoluteAdapterPosition)
         return true
     }
 
@@ -66,8 +66,8 @@ class DragAndDropCallback(
     ) {
         val newDX =
             if (
-                (viewHolder.adapterPosition == 0 && dX < 0) ||
-                (viewHolder.adapterPosition == recyclerView.adapter!!.itemCount - 1 && dX > 0)
+                (viewHolder.absoluteAdapterPosition == 0 && dX < 0) ||
+                (viewHolder.absoluteAdapterPosition == recyclerView.adapter!!.itemCount - 1 && dX > 0)
             ) {
                 0.0f
             } else {

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
@@ -38,7 +38,7 @@ import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.C
 import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.Companion.MAX_EXPIRATION_TIME
 import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.Companion.MAX_PRICE_LENGTH
 import com.fakedevelopers.bidderbidder.ui.productRegistration.PriceTextWatcher.Companion.MAX_TICK_LENGTH
-import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumImageUtils
+import com.fakedevelopers.bidderbidder.ui.util.AlbumImageUtils
 import com.fakedevelopers.bidderbidder.ui.util.ApiErrorHandler
 import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
 import com.fakedevelopers.bidderbidder.ui.util.KeyboardVisibilityUtils
@@ -51,15 +51,21 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okio.BufferedSink
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ProductRegistrationFragment : Fragment() {
+
+    @Inject
+    lateinit var contentResolverUtil: ContentResolverUtil
+
+    @Inject
+    lateinit var albumImageUtils: AlbumImageUtils
 
     private lateinit var keyboardVisibilityUtils: KeyboardVisibilityUtils
     private lateinit var permissionLauncher: ActivityResultLauncher<String>
 
     private var _binding: FragmentProductRegistrationBinding? = null
-
     private val binding get() = _binding!!
     private val viewModel: ProductRegistrationViewModel by viewModels()
     private val backPressedCallback by lazy {
@@ -68,12 +74,6 @@ class ProductRegistrationFragment : Fragment() {
                 findNavController().navigate(R.id.action_productRegistrationFragment_to_productListFragment)
             }
         }
-    }
-    private val contentResolverUtil by lazy {
-        ContentResolverUtil(requireContext())
-    }
-    private val albumImageUtils by lazy {
-        AlbumImageUtils(requireContext())
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
@@ -74,17 +74,9 @@ class ProductRegistrationViewModel @Inject constructor(
 
     private fun swapSelectedImage(fromPosition: Int, toPosition: Int) {
         val list = selectedImageInfo.uris.toMutableList()
-        if (fromPosition < toPosition) {
-            for (i in fromPosition until toPosition) {
-                Collections.swap(list, i, i + 1)
-            }
-        } else {
-            for (i in fromPosition downTo toPosition + 1) {
-                Collections.swap(list, i, i - 1)
-            }
-        }
+        Collections.swap(list, fromPosition, toPosition)
         adapter.submitList(list)
-        selectedImageInfo.uris = list.toMutableList()
+        selectedImageInfo.uris = list
     }
 
     private fun findSelectedImageIndex(uri: String) = selectedImageInfo.uris.indexOf(uri)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationViewModel.kt
@@ -157,8 +157,7 @@ class ProductRegistrationViewModel @Inject constructor(
 
     fun setUrlList(list: List<String>) {
         viewModelScope.launch {
-            adapter.submitList(list)
-            adapter.notifyDataSetChanged()
+            adapter.submitList(list.toMutableList())
         }
         selectedImageInfo.uris = list.toMutableList()
     }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumItem.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumItem.kt
@@ -1,0 +1,6 @@
+package com.fakedevelopers.bidderbidder.ui.productRegistration.albumList
+
+data class AlbumItem(
+    val uri: String,
+    val modifiedTime: Long
+)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListAdapter.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListAdapter.kt
@@ -15,12 +15,12 @@ import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
 import com.fakedevelopers.bidderbidder.ui.util.GlideRequestListener
 
 class AlbumListAdapter(
+    private val contentResolverUtil: ContentResolverUtil,
     private val findSelectedImageIndex: (String) -> Int,
     private val sendErrorToast: () -> Unit,
     private val showViewPager: (String) -> Unit,
     private val setSelectedImageList: (String, Boolean) -> Unit
 ) : ListAdapter<AlbumItem, AlbumListAdapter.ViewHolder>(diffUtil) {
-    private lateinit var contentResolverUtil: ContentResolverUtil
 
     inner class ViewHolder(
         private val binding: RecyclerPictureSelectBinding
@@ -80,7 +80,6 @@ class AlbumListAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        contentResolverUtil = ContentResolverUtil(parent.context)
         return ViewHolder(
             RecyclerPictureSelectBinding.bind(
                 LayoutInflater.from(parent.context).inflate(R.layout.recycler_picture_select, parent, false)
@@ -95,7 +94,7 @@ class AlbumListAdapter(
     companion object {
         val diffUtil = object : DiffUtil.ItemCallback<AlbumItem>() {
             override fun areItemsTheSame(oldItem: AlbumItem, newItem: AlbumItem) =
-                oldItem == newItem
+                oldItem.uri == newItem.uri
 
             override fun areContentsTheSame(oldItem: AlbumItem, newItem: AlbumItem) =
                 oldItem == newItem

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListAdapter.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListAdapter.kt
@@ -1,6 +1,5 @@
 package com.fakedevelopers.bidderbidder.ui.productRegistration.albumList
 
-import android.content.Context
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.View
@@ -20,20 +19,19 @@ class AlbumListAdapter(
     private val sendErrorToast: () -> Unit,
     private val showViewPager: (String) -> Unit,
     private val setSelectedImageList: (String, Boolean) -> Unit
-) : ListAdapter<Pair<String, Long>, AlbumListAdapter.ViewHolder>(diffUtil) {
+) : ListAdapter<AlbumItem, AlbumListAdapter.ViewHolder>(diffUtil) {
     private lateinit var contentResolverUtil: ContentResolverUtil
 
     inner class ViewHolder(
-        private val binding: RecyclerPictureSelectBinding,
-        private val context: Context
+        private val binding: RecyclerPictureSelectBinding
     ) : RecyclerView.ViewHolder(binding.root) {
         private var isErrorImage = false
-        fun bind(item: Pair<String, Long>) {
-            Glide.with(context)
-                .load(item.first)
+        fun bind(item: AlbumItem) {
+            Glide.with(binding.root.context)
+                .load(item.uri)
                 .placeholder(R.drawable.the_cat)
                 .error(R.drawable.error_cat)
-                .signature(ObjectKey(item.second))
+                .signature(ObjectKey(item.modifiedTime))
                 .listener(
                     GlideRequestListener(
                         loadFailed = { isErrorImage = true },
@@ -43,21 +41,21 @@ class AlbumListAdapter(
                 .into(binding.imageviewPictureSelect)
             // 선택된 사진 리스트에 현재 item이 포함되어 있다면 표시해줍니다.
             // 수정된 이미지는 다른 색의 테두리로 수정 여부를 표시
-            findSelectedImageIndex(item.first).let { count ->
-                setPictureSelectCount(count != -1, count + 1)
-                binding.layoutPictureSelectChoice.setOnClickListener {
-                    if (isValidImage(item.first)) {
-                        setSelectedImageList(item.first, binding.backgroundPictrueSelect.visibility != View.VISIBLE)
-                        setPictureSelectCount(binding.backgroundPictrueSelect.visibility != View.VISIBLE, count + 1)
-                    } else {
-                        sendErrorToast()
-                    }
+            val selectedIndex = findSelectedImageIndex(item.uri)
+            setPictureSelectCount(selectedIndex != -1, selectedIndex + 1)
+            binding.layoutPictureSelectChoice.setOnClickListener {
+                if (isValidImage(item.uri)) {
+                    val visibleState = binding.backgroundPictrueSelect.visibility != View.VISIBLE
+                    setSelectedImageList(item.uri, visibleState)
+                    setPictureSelectCount(visibleState, selectedIndex + 1)
+                } else {
+                    sendErrorToast()
                 }
             }
             // 뷰 페이저
             binding.layoutPictureSelectPager.setOnClickListener {
-                if (isValidImage(item.first)) {
-                    showViewPager(item.first)
+                if (isValidImage(item.uri)) {
+                    showViewPager(item.uri)
                 } else {
                     sendErrorToast()
                 }
@@ -86,8 +84,7 @@ class AlbumListAdapter(
         return ViewHolder(
             RecyclerPictureSelectBinding.bind(
                 LayoutInflater.from(parent.context).inflate(R.layout.recycler_picture_select, parent, false)
-            ),
-            parent.context
+            )
         )
     }
 
@@ -96,12 +93,12 @@ class AlbumListAdapter(
     }
 
     companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<Pair<String, Long>>() {
-            override fun areItemsTheSame(oldItem: Pair<String, Long>, newItem: Pair<String, Long>) =
-                oldItem.first == newItem.first && oldItem.second == newItem.second
+        val diffUtil = object : DiffUtil.ItemCallback<AlbumItem>() {
+            override fun areItemsTheSame(oldItem: AlbumItem, newItem: AlbumItem) =
+                oldItem == newItem
 
-            override fun areContentsTheSame(oldItem: Pair<String, Long>, newItem: Pair<String, Long>) =
-                oldItem.first == newItem.first && oldItem.second == newItem.second
+            override fun areContentsTheSame(oldItem: AlbumItem, newItem: AlbumItem) =
+                oldItem == newItem
         }
     }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
@@ -338,15 +338,11 @@ class AlbumListFragment : Fragment() {
 
     // 앨범 리스트 갱신
     // 도중에 추가된 이미지들이 유효한지 검사한다.
-    private fun getValidUpdatedImageList(): List<UpdatedAlbumItem> {
-        val list = mutableListOf<UpdatedAlbumItem>()
-        viewModel.updatedImageList.map { Uri.parse(it) }.filter { contentResolverUtil.isExist(it) }.forEach { uri ->
-            contentResolverUtil.getDateModifiedFromUri(uri)?.let {
-                list.add(UpdatedAlbumItem(uri.toString(), it.first, it.second))
-            }
-        }
-        return list.toList()
-    }
+    private fun getValidUpdatedImageList() =
+        viewModel.updatedImageList
+            .map { Uri.parse(it) }
+            .filter { contentResolverUtil.isExist(it) }
+            .mapNotNull { contentResolverUtil.getDateModifiedFromUri(it) }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
@@ -339,10 +339,7 @@ class AlbumListFragment : Fragment() {
     // 앨범 리스트 갱신
     // 도중에 추가된 이미지들이 유효한지 검사한다.
     private fun getValidUpdatedImageList() =
-        viewModel.updatedImageList
-            .map { Uri.parse(it) }
-            .filter { contentResolverUtil.isExist(it) }
-            .mapNotNull { contentResolverUtil.getDateModifiedFromUri(it) }
+        viewModel.updatedImageList.mapNotNull { contentResolverUtil.getDateModifiedFromUri(Uri.parse(it)) }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
@@ -33,14 +33,20 @@ import com.fakedevelopers.bidderbidder.R
 import com.fakedevelopers.bidderbidder.databinding.FragmentAlbumListBinding
 import com.fakedevelopers.bidderbidder.ui.productRegistration.DragAndDropCallback
 import com.fakedevelopers.bidderbidder.ui.productRegistration.ProductRegistrationDto
-import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumImageUtils.Companion.ROTATE_DEGREE
+import com.fakedevelopers.bidderbidder.ui.util.AlbumImageUtils.Companion.ROTATE_DEGREE
 import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 import kotlin.collections.set
 import kotlin.math.roundToInt
 
+@AndroidEntryPoint
 class AlbumListFragment : Fragment() {
+
+    @Inject
+    lateinit var contentResolverUtil: ContentResolverUtil
 
     private var _binding: FragmentAlbumListBinding? = null
     private val viewModel: AlbumListViewModel by viewModels()
@@ -66,10 +72,6 @@ class AlbumListFragment : Fragment() {
                 setPagerUI(position)
             }
         }
-    }
-
-    private val contentResolverUtil by lazy {
-        ContentResolverUtil(requireContext())
     }
 
     // 외부 저장소에 변화가 생기면 얘가 호출이 됩니다.

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListFragment.kt
@@ -357,8 +357,8 @@ class AlbumListFragment : Fragment() {
         const val MODIFY_IMAGE = BASE_FLAG + NOTIFY_UPDATE
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    override fun onDestroyView() {
+        super.onDestroyView()
         binding.viewpagerPictureSelect.unregisterOnPageChangeCallback(onPageChangeCallback)
         requireActivity().contentResolver.unregisterContentObserver(contentObserver)
         _binding = null

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
@@ -7,14 +7,20 @@ import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumLis
 import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumListFragment.Companion.ALL_PICTURES
 import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumListFragment.Companion.MODIFY_IMAGE
 import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.AlbumListFragment.Companion.REMOVE_IMAGE
+import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
 import com.fakedevelopers.bidderbidder.ui.util.MutableEventFlow
 import com.fakedevelopers.bidderbidder.ui.util.asEventFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.util.Collections
+import javax.inject.Inject
 
-class AlbumListViewModel : ViewModel() {
+@HiltViewModel
+class AlbumListViewModel @Inject constructor(
+    contentResolverUtil: ContentResolverUtil
+) : ViewModel() {
 
     private val currentAlbum = MutableStateFlow("")
     private val _albumViewMode = MutableStateFlow(AlbumViewState.GRID)
@@ -43,6 +49,7 @@ class AlbumListViewModel : ViewModel() {
 
     // 그리드 앨범 리스트 어뎁터
     val albumListAdapter = AlbumListAdapter(
+        contentResolverUtil,
         findSelectedImageIndex = { findSelectedImageIndex(it) },
         sendErrorToast = { viewModelScope.launch { _selectErrorImage.emit(true) } },
         showViewPager = { uri -> showViewPager(uri) }
@@ -52,6 +59,7 @@ class AlbumListViewModel : ViewModel() {
 
     // 뷰 페이저 앨범 리스트 어뎁터
     val albumPagerAdapter = AlbumPagerAdapter(
+        contentResolverUtil,
         sendErrorToast = { viewModelScope.launch { _selectErrorImage.emit(true) } },
         getEditedImage = { uri -> getEditedBitmapInfo(uri) }
     ) { uri ->
@@ -116,8 +124,7 @@ class AlbumListViewModel : ViewModel() {
     }
 
     fun setSelectedImage(list: List<String>) {
-        val invalidList = selectedImageInfo.uris.filter { !list.contains(it) }
-        for (uri in invalidList) {
+        selectedImageInfo.uris.filter { !list.contains(it) }.forEach { uri ->
             removeInvalidImage(uri)
         }
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
@@ -280,15 +280,7 @@ class AlbumListViewModel @Inject constructor(
     }
 
     private fun swapSelectedImage(fromPosition: Int, toPosition: Int) {
-        if (fromPosition < toPosition) {
-            for (i in fromPosition until toPosition) {
-                Collections.swap(selectedImageInfo.uris, i, i + 1)
-            }
-        } else {
-            for (i in fromPosition downTo toPosition + 1) {
-                Collections.swap(selectedImageInfo.uris, i, i - 1)
-            }
-        }
+        Collections.swap(selectedImageInfo.uris, fromPosition, toPosition)
         selectedPictureAdapter.submitList(mutableListOf<String>().apply { addAll(selectedImageInfo.uris) })
         albumListAdapter.notifyDataSetChanged()
         albumPagerAdapter.notifyDataSetChanged()

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
@@ -21,30 +21,37 @@ import javax.inject.Inject
 class AlbumListViewModel @Inject constructor(
     contentResolverUtil: ContentResolverUtil
 ) : ViewModel() {
-
-    private val currentAlbum = MutableStateFlow("")
     private val _albumViewMode = MutableStateFlow(AlbumViewState.GRID)
+    val albumViewMode: StateFlow<AlbumViewState> get() = _albumViewMode
+
     private val _onListChange = MutableEventFlow<Boolean>()
+    val onListChange = _onListChange.asEventFlow()
+
     private val _pagerSelectedState = MutableEventFlow<Boolean>()
+    val pagerSelectedState = _pagerSelectedState.asEventFlow()
+
     private val _selectErrorImage = MutableEventFlow<Boolean>()
+    val selectErrorImage = _selectErrorImage.asEventFlow()
+
     private val _startViewPagerIndex = MutableEventFlow<Int>()
+    val startViewPagerIndex = _startViewPagerIndex.asEventFlow()
+
     private val _editButtonEnableState = MutableStateFlow(false)
+    val editButtonEnableState: StateFlow<Boolean> get() = _editButtonEnableState
+
+    private var currentAlbum = ""
+    private var totalPictureCount = 0
+    private var allImages = mapOf<String, MutableList<AlbumItem>>()
     private val _addedImageList = hashSetOf<String>()
     private val removedImageList = hashSetOf<String>()
-    private var totalPictureCount = 0
-    private lateinit var allImages: Map<String, MutableList<AlbumItem>>
-
-    val albumViewMode: StateFlow<AlbumViewState> get() = _albumViewMode
-    val onListChange = _onListChange.asEventFlow()
-    val pagerSelectedState = _pagerSelectedState.asEventFlow()
-    val startViewPagerIndex = _startViewPagerIndex.asEventFlow()
-    val editButtonEnableState: StateFlow<Boolean> get() = _editButtonEnableState
-    val selectErrorImage = _selectErrorImage.asEventFlow()
     val addedImageList: Set<String> get() = _addedImageList
     val selectedImageInfo = SelectedImageInfo()
 
     // 현재 뷰 페이저 인덱스
     var currentViewPagerIdx = 0
+        private set
+    // 앨범 전환 시 리스트를 탑으로 올리기 위한 플래그
+    var scrollToTopFlag = false
         private set
 
     // 그리드 앨범 리스트 어뎁터
@@ -74,9 +81,6 @@ class AlbumListViewModel @Inject constructor(
     ) { fromPosition, toPosition ->
         swapSelectedImage(fromPosition, toPosition)
     }
-
-    // 앨범 전환 시 리스트를 탑으로 올리기 위한 플래그
-    var scrollToTopFlag = false
 
     fun initSelectedImageList(selectedImageInfo: SelectedImageInfo) {
         this.selectedImageInfo.apply {
@@ -143,20 +147,18 @@ class AlbumListViewModel @Inject constructor(
             selectedImageInfo.uris.add(uri)
         } else {
             val idx = findSelectedImageIndex(uri)
-            selectedImageInfo.run {
-                uris.removeAt(idx)
-                // 수정된 내용(BitmapInfo)도 같이 삭제
-                if (changeBitmaps.contains(uri)) {
-                    changeBitmaps.remove(uri)
-                    // 페이저에 보이는 이미지 원상 복구
-                    allImages[currentAlbum.value]?.let { list ->
-                        albumPagerAdapter.notifyItemChanged(list.indexOfFirst { it.uri == uri })
-                    }
+            selectedImageInfo.uris.removeAt(idx)
+            // 수정된 내용(BitmapInfo)도 같이 삭제
+            if (selectedImageInfo.changeBitmaps.contains(uri)) {
+                selectedImageInfo.changeBitmaps.remove(uri)
+                // 페이저에 보이는 이미지 원상 복구
+                allImages[currentAlbum]?.let { list ->
+                    albumPagerAdapter.notifyItemChanged(list.indexOfFirst { it.uri == uri })
                 }
-                // 첫번째 사진이 삭제 된다면 다음 사진에게 대표직을 물려줌
-                if (uris.isNotEmpty() && idx == 0) {
-                    selectedPictureAdapter.notifyItemChanged(1)
-                }
+            }
+            // 첫번째 사진이 삭제 된다면 다음 사진에게 대표직을 물려줌
+            if (selectedImageInfo.uris.isNotEmpty() && idx == 0) {
+                selectedPictureAdapter.notifyItemChanged(1)
             }
         }
         // 현재 보기 모드가 페이저라면 선택 상태를 변경해준다.
@@ -174,9 +176,9 @@ class AlbumListViewModel @Inject constructor(
 
     fun getCurrentPositionString(position: Int) = "$position / $totalPictureCount"
 
-    fun getCurrentUri() = allImages[currentAlbum.value]?.get(currentViewPagerIdx)?.uri ?: ""
+    fun getCurrentUri() = allImages[currentAlbum]?.get(currentViewPagerIdx)?.uri ?: ""
 
-    fun getPictureUri(albumName: String = currentAlbum.value, position: Int) =
+    fun getPictureUri(albumName: String = currentAlbum, position: Int) =
         allImages[albumName]?.get(position)?.uri ?: ""
 
     // 수정된 비트맵 가져오기
@@ -184,7 +186,7 @@ class AlbumListViewModel @Inject constructor(
         selectedImageInfo.changeBitmaps[uri]
 
     fun isAlbumListChanged() =
-        albumListAdapter.currentList[0] == allImages[currentAlbum.value]?.get(0)
+        albumListAdapter.currentList[0] == allImages[currentAlbum]?.get(0)
 
     fun onAlbumListChanged(uri: String, type: Int) {
         when (type) {
@@ -204,7 +206,7 @@ class AlbumListViewModel @Inject constructor(
 
     fun updateAlbumList(
         validAddedImageList: List<Triple<String, String, Long>>,
-        albumName: String = currentAlbum.value
+        albumName: String = currentAlbum
     ) {
         if (removedImageList.isNotEmpty()) {
             // 앨범 리스트 갱신
@@ -240,7 +242,7 @@ class AlbumListViewModel @Inject constructor(
         }
     }
 
-    private fun setAdapterList(albumName: String = currentAlbum.value) {
+    private fun setAdapterList(albumName: String = currentAlbum) {
         allImages[albumName]?.let { list ->
             val currentList = mutableListOf<AlbumItem>().apply { addAll(list) }
             albumListAdapter.submitList(currentList)
@@ -249,18 +251,16 @@ class AlbumListViewModel @Inject constructor(
         }
         albumListAdapter.notifyDataSetChanged()
         selectedPictureAdapter.notifyDataSetChanged()
-        if (albumName != currentAlbum.value) {
-            viewModelScope.launch {
-                currentAlbum.emit(albumName)
-                // 앨범을 바꿀 때 최상위 스크롤을 해주는 플래그를 true로 바꿔준다.
-                setScrollFlag()
-            }
+        if (albumName != currentAlbum) {
+            currentAlbum = albumName
+            // 앨범을 바꿀 때 최상위 스크롤을 해주는 플래그를 true로 바꿔준다.
+            setScrollFlag()
         }
     }
 
     // 앨범 뷰 페이저
     private fun showViewPager(uri: String) {
-        allImages[currentAlbum.value]?.let { album ->
+        allImages[currentAlbum]?.let { album ->
             val idx = album.indexOf(album.find { it.uri == uri })
             if (idx != -1) {
                 viewModelScope.launch {
@@ -272,7 +272,7 @@ class AlbumListViewModel @Inject constructor(
     }
 
     private fun setSelectedImageList() {
-        selectedPictureAdapter.submitList(mutableListOf<String>().apply { addAll(selectedImageInfo.uris) })
+        selectedPictureAdapter.submitList(selectedImageInfo.uris.toMutableList())
         albumListAdapter.notifyDataSetChanged()
         viewModelScope.launch {
             _onListChange.emit(true)
@@ -281,7 +281,7 @@ class AlbumListViewModel @Inject constructor(
 
     private fun swapSelectedImage(fromPosition: Int, toPosition: Int) {
         Collections.swap(selectedImageInfo.uris, fromPosition, toPosition)
-        selectedPictureAdapter.submitList(mutableListOf<String>().apply { addAll(selectedImageInfo.uris) })
+        selectedPictureAdapter.submitList(selectedImageInfo.uris.toMutableList())
         albumListAdapter.notifyDataSetChanged()
         albumPagerAdapter.notifyDataSetChanged()
     }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
@@ -150,8 +150,7 @@ class AlbumListViewModel @Inject constructor(
             val idx = findSelectedImageIndex(uri)
             selectedImageInfo.uris.removeAt(idx)
             // 수정된 내용(BitmapInfo)도 같이 삭제
-            if (selectedImageInfo.changeBitmaps.contains(uri)) {
-                selectedImageInfo.changeBitmaps.remove(uri)
+            if (selectedImageInfo.changeBitmaps.remove(uri) != null) {
                 // 페이저에 보이는 이미지 원상 복구
                 allImages[currentAlbum]?.let { list ->
                     albumPagerAdapter.notifyItemChanged(list.indexOfFirst { it.uri == uri })

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumListViewModel.kt
@@ -50,6 +50,7 @@ class AlbumListViewModel @Inject constructor(
     // 현재 뷰 페이저 인덱스
     var currentViewPagerIdx = 0
         private set
+
     // 앨범 전환 시 리스트를 탑으로 올리기 위한 플래그
     var scrollToTopFlag = false
         private set

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumPagerAdapter.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumPagerAdapter.kt
@@ -14,11 +14,11 @@ import com.fakedevelopers.bidderbidder.ui.util.ContentResolverUtil
 import com.fakedevelopers.bidderbidder.ui.util.GlideRequestListener
 
 class AlbumPagerAdapter(
+    private val contentResolverUtil: ContentResolverUtil,
     private val sendErrorToast: () -> Unit,
     private val getEditedImage: (String) -> BitmapInfo?,
     private val setSelectedImageList: (String) -> Unit
 ) : ListAdapter<AlbumItem, AlbumPagerAdapter.ViewHolder>(diffUtil) {
-    private lateinit var contentResolverUtil: ContentResolverUtil
 
     inner class ViewHolder(
         private val binding: RecyclerAlbumPagerBinding
@@ -57,7 +57,6 @@ class AlbumPagerAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        contentResolverUtil = ContentResolverUtil(parent.context)
         return ViewHolder(
             RecyclerAlbumPagerBinding.bind(
                 LayoutInflater.from(parent.context).inflate(R.layout.recycler_album_pager, parent, false)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumPagerAdapter.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/AlbumPagerAdapter.kt
@@ -1,6 +1,5 @@
 package com.fakedevelopers.bidderbidder.ui.productRegistration.albumList
 
-import android.content.Context
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -18,34 +17,33 @@ class AlbumPagerAdapter(
     private val sendErrorToast: () -> Unit,
     private val getEditedImage: (String) -> BitmapInfo?,
     private val setSelectedImageList: (String) -> Unit
-) : ListAdapter<Pair<String, Long>, AlbumPagerAdapter.ViewHolder>(diffUtil) {
+) : ListAdapter<AlbumItem, AlbumPagerAdapter.ViewHolder>(diffUtil) {
     private lateinit var contentResolverUtil: ContentResolverUtil
 
     inner class ViewHolder(
-        private val binding: RecyclerAlbumPagerBinding,
-        private val context: Context
+        private val binding: RecyclerAlbumPagerBinding
     ) : RecyclerView.ViewHolder(binding.root) {
         private var isErrorImage = false
-        fun bind(item: Pair<String, Long>) {
-            getEditedImage(item.first)?.let { bitmapInfo ->
+        fun bind(item: AlbumItem) {
+            getEditedImage(item.uri)?.let { bitmapInfo ->
                 binding.imageviewAlbumPager.rotation = bitmapInfo.degree
             } ?: run { binding.imageviewAlbumPager.rotation = 0f }
             setGlide(item)
             binding.layoutAlbumPager.setOnClickListener {
-                if (isValidImage(item.first)) {
-                    setSelectedImageList(item.first)
+                if (isValidImage(item.uri)) {
+                    setSelectedImageList(item.uri)
                 } else {
                     sendErrorToast()
                 }
             }
         }
 
-        private fun setGlide(item: Pair<String, Long>) {
-            Glide.with(context)
-                .load(item.first)
+        private fun setGlide(item: AlbumItem) {
+            Glide.with(binding.root.context)
+                .load(item.uri)
                 .placeholder(R.drawable.the_cat)
                 .error(R.drawable.error_cat)
-                .signature(ObjectKey(item.second))
+                .signature(ObjectKey(item.modifiedTime))
                 .listener(
                     GlideRequestListener(
                         loadFailed = { isErrorImage = true },
@@ -63,8 +61,7 @@ class AlbumPagerAdapter(
         return ViewHolder(
             RecyclerAlbumPagerBinding.bind(
                 LayoutInflater.from(parent.context).inflate(R.layout.recycler_album_pager, parent, false)
-            ),
-            parent.context
+            )
         )
     }
 

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/UpdatedAlbumItem.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/albumList/UpdatedAlbumItem.kt
@@ -1,0 +1,7 @@
+package com.fakedevelopers.bidderbidder.ui.productRegistration.albumList
+
+data class UpdatedAlbumItem(
+    val uri: String,
+    val path: String,
+    val modified: Long
+)

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/AlbumImageUtils.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/AlbumImageUtils.kt
@@ -1,6 +1,6 @@
-package com.fakedevelopers.bidderbidder.ui.productRegistration.albumList
+package com.fakedevelopers.bidderbidder.ui.util
 
-import android.content.Context
+import android.content.ContentResolver
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.graphics.Matrix
@@ -13,8 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.Locale
 
-class AlbumImageUtils(val context: Context) {
-
+class AlbumImageUtils(
+    private val contentResolver: ContentResolver
+) {
     // getBitmap은 API 29에서 Deprecated 됐읍니다.
     @Suppress("DEPRECATION")
     suspend fun getBitmapByURI(uri: String, dispatcher: CoroutineDispatcher = Dispatchers.IO) =
@@ -22,10 +23,10 @@ class AlbumImageUtils(val context: Context) {
             var bitmap: Bitmap? = null
             runCatching {
                 if (Build.VERSION.SDK_INT >= 28) {
-                    ImageDecoder.decodeBitmap(ImageDecoder.createSource(context.contentResolver, Uri.parse(uri)))
+                    ImageDecoder.decodeBitmap(ImageDecoder.createSource(contentResolver, Uri.parse(uri)))
                 } else {
                     // API 28 이하는 createSource 사용 불가
-                    MediaStore.Images.Media.getBitmap(context.contentResolver, Uri.parse(uri))
+                    MediaStore.Images.Media.getBitmap(contentResolver, Uri.parse(uri))
                 }
             }.onSuccess {
                 bitmap = it
@@ -34,7 +35,7 @@ class AlbumImageUtils(val context: Context) {
         }
 
     fun getMimeTypeAndExtension(uri: String): Pair<String, String> {
-        val mimeType = context.contentResolver.getType(Uri.parse(uri)).toString()
+        val mimeType = contentResolver.getType(Uri.parse(uri)).toString()
         var extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType).toString()
         if (extension == "jpg") {
             extension = "jpeg"

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -1,11 +1,12 @@
 package com.fakedevelopers.bidderbidder.ui.util
 
-import android.content.Context
+import android.content.ContentResolver
 import android.net.Uri
 import android.provider.MediaStore
 
-class ContentResolverUtil(context: Context) {
-    private val contentResolver = context.contentResolver
+class ContentResolverUtil(
+    private val contentResolver: ContentResolver
+) {
 
     fun isExist(uri: Uri): Boolean {
         contentResolver.runCatching {

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -3,6 +3,7 @@ package com.fakedevelopers.bidderbidder.ui.util
 import android.content.ContentResolver
 import android.net.Uri
 import android.provider.MediaStore
+import com.fakedevelopers.bidderbidder.ui.productRegistration.albumList.UpdatedAlbumItem
 
 class ContentResolverUtil(
     private val contentResolver: ContentResolver
@@ -30,7 +31,7 @@ class ContentResolverUtil(
         return if (invalidSelectedImageList.isNotEmpty()) validSelectedImageList else uriList
     }
 
-    fun getDateModifiedFromUri(uri: Uri): Pair<String, Long>? =
+    fun getDateModifiedFromUri(uri: Uri): UpdatedAlbumItem? =
         contentResolver.query(
             uri,
             arrayOf(
@@ -46,6 +47,6 @@ class ContentResolverUtil(
             val token = path.split("/")
             val modified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
             cursor.close()
-            token[token.lastIndex - 1] to modified
+            UpdatedAlbumItem(uri.toString(), token[token.lastIndex - 1], modified)
         }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -42,11 +42,15 @@ class ContentResolverUtil(
             null,
             null
         )?.let { cursor ->
-            cursor.moveToNext()
-            val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA))
-            val token = path.split("/")
-            val modified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
+            var updatedAlbumItem: UpdatedAlbumItem? = null
+            val result = cursor.moveToNext()
+            if (result) {
+                val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA))
+                val token = path.split("/")
+                val modified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
+                updatedAlbumItem = UpdatedAlbumItem(uri.toString(), token[token.lastIndex - 1], modified)
+            }
             cursor.close()
-            UpdatedAlbumItem(uri.toString(), token[token.lastIndex - 1], modified)
+            updatedAlbumItem
         }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -30,23 +30,22 @@ class ContentResolverUtil(
         return if (invalidSelectedImageList.isNotEmpty()) validSelectedImageList else uriList
     }
 
-    fun getDateModifiedFromUri(uri: Uri): Pair<String, Long> {
+    fun getDateModifiedFromUri(uri: Uri): Pair<String, Long>? =
         contentResolver.query(
             uri,
             arrayOf(
-                MediaStore.Images.Media.RELATIVE_PATH,
+                MediaStore.Images.Media.DATA,
                 MediaStore.Images.ImageColumns.DATE_MODIFIED
             ),
             null,
             null,
             null
-        )?.let {
-            it.moveToNext()
-            val relativePath = it.getString(it.getColumnIndexOrThrow(MediaStore.Images.Media.RELATIVE_PATH))
-            val dateModified = it.getLong(it.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
-            it.close()
-            return relativePath to dateModified
+        )?.let { cursor ->
+            cursor.moveToNext()
+            val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA))
+            val token = path.split("/")
+            val modified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
+            cursor.close()
+            token[token.lastIndex - 1] to modified
         }
-        return "" to 0L
-    }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -47,8 +47,11 @@ class ContentResolverUtil(
             if (result) {
                 val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA))
                 val token = path.split("/")
-                val modified = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
-                updatedAlbumItem = UpdatedAlbumItem(uri.toString(), token[token.lastIndex - 1], modified)
+                updatedAlbumItem = UpdatedAlbumItem(
+                    uri.toString(),
+                    token[token.lastIndex - 1],
+                    cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
+                )
             }
             cursor.close()
             updatedAlbumItem

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/ContentResolverUtil.kt
@@ -46,10 +46,10 @@ class ContentResolverUtil(
             val result = cursor.moveToNext()
             if (result) {
                 val path = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA))
-                val token = path.split("/")
+                val token = path.substringBeforeLast("/")
                 updatedAlbumItem = UpdatedAlbumItem(
                     uri.toString(),
-                    token[token.lastIndex - 1],
+                    token,
                     cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.DATE_MODIFIED))
                 )
             }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/UtilModule.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/util/UtilModule.kt
@@ -1,0 +1,24 @@
+package com.fakedevelopers.bidderbidder.ui.util
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UtilModule {
+
+    @Singleton
+    @Provides
+    fun provideContentResolverUtil(@ApplicationContext context: Context) =
+        ContentResolverUtil(context.contentResolver)
+
+    @Singleton
+    @Provides
+    fun provideAlbumImageUtil(@ApplicationContext context: Context) =
+        AlbumImageUtils(context.contentResolver)
+}


### PR DESCRIPTION
### 개요
* 사진 선택 동작 최적화

### 변경사항
* ContentResolverUtil, AlbumImageUtils 의존성 주입 적용
* 이미지 경로를 RELATIVE_PATH 대신 DATA를 통해서 가져오는 방식으로 변경
  * RELATIVE_PATH는 매-우 최신 방식으로 하위 버전에서는 동작하지 않았습니다.
* 코드를 이쁘게 다듬었습니다.
* ContentObserver에서 플래그를 가져오지 않는 onChange 메소드로 변경
  * 플래그를 가져오는 onChange 메소드는 매-우 최신 방식으로 하위 버전에서는 동작하지 않았습니다.

### 관련 지라 및 위키 링크
[BDBD-482](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-482)

### 리뷰어에게 하고 싶은 말
* ~~현재 휴대폰의 외부 저장소 변화를 감지하는 ContentObserver의 동작 방식이 매-우 최신이라 하위 버전에서는 동작하지 않는 문제가 있습니다.~~
* ~~이 부분을 갈아치울라면 시간이 더 필요해 보여서 일단 작업한 내용만 올립니다~~
* 고쳤어요 ㅎㅎ..