### PR TITLE
FEAT : BDBD-503 로그인 / 메인 액티비티 분리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:theme="@style/Theme.BidderBidder">
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <activity
-            android:name=".ui.MainActivity"
+            android:name=".ui.LoginActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
@@ -25,5 +25,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.MainActivity"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:theme="@style/Theme.BidderBidder">
         <meta-data android:name="io.sentry.auto-init" android:value="false" />
         <activity
-            android:name=".MainActivity"
+            android:name=".ui.MainActivity"
             android:exported="true"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/ApiModule.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/ApiModule.kt
@@ -1,22 +1,6 @@
 package com.fakedevelopers.bidderbidder.api.di
 
 import com.fakedevelopers.bidderbidder.api.data.Constants.Companion.BASE_URL
-import com.fakedevelopers.bidderbidder.api.repository.ChatRepository
-import com.fakedevelopers.bidderbidder.api.repository.ProductCategoryRepository
-import com.fakedevelopers.bidderbidder.api.repository.ProductDetailRepository
-import com.fakedevelopers.bidderbidder.api.repository.ProductListRepository
-import com.fakedevelopers.bidderbidder.api.repository.ProductRegistrationRepository
-import com.fakedevelopers.bidderbidder.api.repository.ProductSearchRepository
-import com.fakedevelopers.bidderbidder.api.repository.SigninGoogleRepository
-import com.fakedevelopers.bidderbidder.api.repository.UserLoginRepository
-import com.fakedevelopers.bidderbidder.api.service.ChatService
-import com.fakedevelopers.bidderbidder.api.service.ProductCategoryService
-import com.fakedevelopers.bidderbidder.api.service.ProductDetailService
-import com.fakedevelopers.bidderbidder.api.service.ProductListService
-import com.fakedevelopers.bidderbidder.api.service.ProductRegistrationService
-import com.fakedevelopers.bidderbidder.api.service.ProductSearchService
-import com.fakedevelopers.bidderbidder.api.service.SigninGoogleService
-import com.fakedevelopers.bidderbidder.api.service.UserLoginService
 import com.fakedevelopers.bidderbidder.api.util.LoginAuthInterceptor
 import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
@@ -123,94 +107,6 @@ object ApiModule {
             setLanguageCode(Locale.getDefault().language)
         }
     }
-
-    // 로그인 요청
-    @Singleton
-    @Provides
-    fun provideUserLoginService(@NormalRetrofit retrofit: Retrofit): UserLoginService = retrofit.create(
-        UserLoginService::class.java
-    )
-
-    @Singleton
-    @Provides
-    fun provideUserLoginRepository(service: UserLoginService): UserLoginRepository = UserLoginRepository(service)
-
-    // 게시글 등록 요청
-    @Singleton
-    @Provides
-    fun provideUserProductRegistrationService(@NormalRetrofit retrofit: Retrofit): ProductRegistrationService =
-        retrofit.create(ProductRegistrationService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideUserProductRegistrationRepository(service: ProductRegistrationService): ProductRegistrationRepository =
-        ProductRegistrationRepository(service)
-
-    // 상품 카테고리 요청
-    @Singleton
-    @Provides
-    fun provideProductCategoryService(@NormalRetrofit retrofit: Retrofit): ProductCategoryService =
-        retrofit.create(ProductCategoryService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideProductCategoryRepository(service: ProductCategoryService): ProductCategoryRepository =
-        ProductCategoryRepository(service)
-
-    // 상품 리스트 요청
-    @Singleton
-    @Provides
-    fun provideProductListService(@NormalRetrofit retrofit: Retrofit): ProductListService =
-        retrofit.create(ProductListService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideProductListRepository(service: ProductListService): ProductListRepository =
-        ProductListRepository(service)
-
-    // 구글 로그인 요청
-    @Singleton
-    @Provides
-    fun provideSigninGoogleService(@AuthRetrofit retrofit: Retrofit): SigninGoogleService =
-        retrofit.create(SigninGoogleService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideSigninGoogleRepository(service: SigninGoogleService): SigninGoogleRepository =
-        SigninGoogleRepository(service)
-
-    // 상품 상세 정보, 입찰
-    @Singleton
-    @Provides
-    fun provideProductDetailService(@NormalRetrofit retrofit: Retrofit): ProductDetailService =
-        retrofit.create(ProductDetailService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideProductDetailRepository(service: ProductDetailService): ProductDetailRepository =
-        ProductDetailRepository(service)
-
-    // 스트림 유저 토큰
-    @Singleton
-    @Provides
-    fun provideChatService(@NormalRetrofit retrofit: Retrofit): ChatService =
-        retrofit.create(ChatService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideChatRepository(service: ChatService): ChatRepository =
-        ChatRepository(service)
-
-    // 인기 검색어 요청
-    @Singleton
-    @Provides
-    fun provideProductSearchService(@NormalRetrofit retrofit: Retrofit): ProductSearchService =
-        retrofit.create(ProductSearchService::class.java)
-
-    @Singleton
-    @Provides
-    fun provideProductSearchRepository(service: ProductSearchService): ProductSearchRepository =
-        ProductSearchRepository(service)
 
     @Singleton
     @Provides

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/LoginModule.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/LoginModule.kt
@@ -1,0 +1,38 @@
+package com.fakedevelopers.bidderbidder.api.di
+
+import com.fakedevelopers.bidderbidder.api.repository.SigninGoogleRepository
+import com.fakedevelopers.bidderbidder.api.repository.UserLoginRepository
+import com.fakedevelopers.bidderbidder.api.service.SigninGoogleService
+import com.fakedevelopers.bidderbidder.api.service.UserLoginService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(ViewModelComponent::class)
+class LoginModule {
+    // 로그인 요청
+    @ViewModelScoped
+    @Provides
+    fun provideUserLoginService(@NormalRetrofit retrofit: Retrofit): UserLoginService = retrofit.create(
+        UserLoginService::class.java
+    )
+
+    @ViewModelScoped
+    @Provides
+    fun provideUserLoginRepository(service: UserLoginService): UserLoginRepository = UserLoginRepository(service)
+
+    // 구글 로그인 요청
+    @ViewModelScoped
+    @Provides
+    fun provideSigninGoogleService(@AuthRetrofit retrofit: Retrofit): SigninGoogleService =
+        retrofit.create(SigninGoogleService::class.java)
+
+    @ViewModelScoped
+    @Provides
+    fun provideSigninGoogleRepository(service: SigninGoogleService): SigninGoogleRepository =
+        SigninGoogleRepository(service)
+}

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/MainModule.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/MainModule.kt
@@ -1,0 +1,90 @@
+package com.fakedevelopers.bidderbidder.api.di
+
+import com.fakedevelopers.bidderbidder.api.repository.ChatRepository
+import com.fakedevelopers.bidderbidder.api.repository.ProductCategoryRepository
+import com.fakedevelopers.bidderbidder.api.repository.ProductDetailRepository
+import com.fakedevelopers.bidderbidder.api.repository.ProductListRepository
+import com.fakedevelopers.bidderbidder.api.repository.ProductRegistrationRepository
+import com.fakedevelopers.bidderbidder.api.repository.ProductSearchRepository
+import com.fakedevelopers.bidderbidder.api.service.ChatService
+import com.fakedevelopers.bidderbidder.api.service.ProductCategoryService
+import com.fakedevelopers.bidderbidder.api.service.ProductDetailService
+import com.fakedevelopers.bidderbidder.api.service.ProductListService
+import com.fakedevelopers.bidderbidder.api.service.ProductRegistrationService
+import com.fakedevelopers.bidderbidder.api.service.ProductSearchService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import retrofit2.Retrofit
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+class MainModule {
+    // 게시글 등록 요청
+    @ActivityRetainedScoped
+    @Provides
+    fun provideUserProductRegistrationService(@NormalRetrofit retrofit: Retrofit): ProductRegistrationService =
+        retrofit.create(ProductRegistrationService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideUserProductRegistrationRepository(service: ProductRegistrationService): ProductRegistrationRepository =
+        ProductRegistrationRepository(service)
+
+    // 상품 카테고리 요청
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductCategoryService(@NormalRetrofit retrofit: Retrofit): ProductCategoryService =
+        retrofit.create(ProductCategoryService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductCategoryRepository(service: ProductCategoryService): ProductCategoryRepository =
+        ProductCategoryRepository(service)
+
+    // 상품 리스트 요청
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductListService(@NormalRetrofit retrofit: Retrofit): ProductListService =
+        retrofit.create(ProductListService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductListRepository(service: ProductListService): ProductListRepository =
+        ProductListRepository(service)
+
+    // 상품 상세 정보, 입찰
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductDetailService(@NormalRetrofit retrofit: Retrofit): ProductDetailService =
+        retrofit.create(ProductDetailService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductDetailRepository(service: ProductDetailService): ProductDetailRepository =
+        ProductDetailRepository(service)
+
+    // 스트림 유저 토큰
+    @ActivityRetainedScoped
+    @Provides
+    fun provideChatService(@NormalRetrofit retrofit: Retrofit): ChatService =
+        retrofit.create(ChatService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideChatRepository(service: ChatService): ChatRepository =
+        ChatRepository(service)
+
+    // 인기 검색어 요청
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductSearchService(@NormalRetrofit retrofit: Retrofit): ProductSearchService =
+        retrofit.create(ProductSearchService::class.java)
+
+    @ActivityRetainedScoped
+    @Provides
+    fun provideProductSearchRepository(service: ProductSearchService): ProductSearchRepository =
+        ProductSearchRepository(service)
+}

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/LoginActivity.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/LoginActivity.kt
@@ -1,0 +1,6 @@
+package com.fakedevelopers.bidderbidder.ui
+
+import androidx.appcompat.app.AppCompatActivity
+
+class LoginActivity : AppCompatActivity() {
+}

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/LoginActivity.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/LoginActivity.kt
@@ -1,6 +1,15 @@
 package com.fakedevelopers.bidderbidder.ui
 
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.fakedevelopers.bidderbidder.R
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+    }
 }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.fakedevelopers.bidderbidder
+package com.fakedevelopers.bidderbidder.ui
 
 import android.os.Bundle
 import android.view.MotionEvent
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
+import com.fakedevelopers.bidderbidder.R
 import com.fakedevelopers.bidderbidder.databinding.ActivityMainBinding
 import com.jakewharton.threetenabp.AndroidThreeTen
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/login/LoginFragment.kt
@@ -1,5 +1,6 @@
 package com.fakedevelopers.bidderbidder.ui.login
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -14,6 +15,7 @@ import androidx.navigation.fragment.findNavController
 import com.fakedevelopers.bidderbidder.R
 import com.fakedevelopers.bidderbidder.api.data.Constants.Companion.LOGIN_SUCCESS
 import com.fakedevelopers.bidderbidder.databinding.FragmentLoginBinding
+import com.fakedevelopers.bidderbidder.ui.MainActivity
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -68,10 +70,9 @@ class LoginFragment : Fragment() {
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.loginResponse.collect {
-                    if (it.isSuccessful) {
-                        if (it.body().toString() == LOGIN_SUCCESS) {
-                            findNavController().navigate(R.id.action_loginFragment_to_mainFragment)
-                        }
+                    if (it.isSuccessful && it.body().toString() == LOGIN_SUCCESS) {
+                        startActivity(Intent(requireContext(), MainActivity::class.java))
+                        requireActivity().finish()
                     } else {
                         Logger.e(it.errorBody().toString())
                     }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/loginType/LoginTypeFragment.kt
@@ -1,6 +1,7 @@
 package com.fakedevelopers.bidderbidder.ui.loginType
 
 import android.app.Activity.RESULT_OK
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -18,6 +19,7 @@ import com.fakedevelopers.bidderbidder.HiltApplication
 import com.fakedevelopers.bidderbidder.R
 import com.fakedevelopers.bidderbidder.api.data.Constants.Companion.WEB_CLIENT_ID
 import com.fakedevelopers.bidderbidder.databinding.FragmentLoginTypeBinding
+import com.fakedevelopers.bidderbidder.ui.MainActivity
 import com.google.android.gms.auth.api.Auth
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -95,7 +97,8 @@ class LoginTypeFragment : Fragment() {
                 viewModel.signinGoogleResponse.collect {
                     if (it.isSuccessful) {
                         Toast.makeText(requireActivity(), "success", Toast.LENGTH_LONG).show()
-                        findNavController().navigate(R.id.action_loginTypeFragment_to_productListFragment)
+                        startActivity(Intent(requireContext(), MainActivity::class.java))
+                        requireActivity().finish()
                     } else {
                         Toast.makeText(requireActivity(), "failure", Toast.LENGTH_LONG).show()
                     }

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productList/ProductListFragment.kt
@@ -78,11 +78,7 @@ class ProductListFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         val args: ProductListFragmentArgs by navArgs()
         if (viewModel.isInitialize) {
-            kotlin.runCatching {
-                args.searchWord
-            }.onSuccess {
-                viewModel.setSearchWord(it)
-            }
+            viewModel.setSearchWord(args.searchWord)
             viewModel.requestProductList(true)
         }
         initListener()

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/register/UserRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/register/UserRegistrationFragment.kt
@@ -1,5 +1,6 @@
 package com.fakedevelopers.bidderbidder.ui.register
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -15,10 +16,10 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.fragment.findNavController
 import androidx.navigation.navOptions
 import com.fakedevelopers.bidderbidder.R
 import com.fakedevelopers.bidderbidder.databinding.FragmentUserRegistrationBinding
+import com.fakedevelopers.bidderbidder.ui.MainActivity
 import com.fakedevelopers.bidderbidder.ui.register.RegistrationProgressState.ACCEPT_TERMS
 import com.fakedevelopers.bidderbidder.ui.register.RegistrationProgressState.CONGRATULATIONS
 import com.fakedevelopers.bidderbidder.ui.register.RegistrationProgressState.INPUT_ID
@@ -159,7 +160,10 @@ class UserRegistrationFragment : Fragment() {
             INPUT_ID -> navigate(R.id.userRegistrationIdFragment)
             INPUT_PASSWORD -> navigate(R.id.userRegistrationPasswordFragment)
             PHONE_AUTH_BEFORE_SENDING -> navigate(R.id.phoneAuthFragment)
-            CONGRATULATIONS -> findNavController().navigate(R.id.action_userRegistrationFragment_to_productListFragment)
+            CONGRATULATIONS -> {
+                startActivity(Intent(requireContext(), MainActivity::class.java))
+                requireActivity().finish()
+            }
             else -> {
                 // 여긴 아무것도 안해!
             }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/navigation_login"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/login_graph"
+        tools:layout="@layout/fragment_login_type" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context=".MainActivity">
+    tools:context=".ui.MainActivity">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/navigation_main"

--- a/app/src/main/res/navigation/login_graph.xml
+++ b/app/src/main/res/navigation/login_graph.xml
@@ -10,17 +10,21 @@
         android:name="com.fakedevelopers.bidderbidder.ui.loginType.LoginTypeFragment"
         android:label="LoginTypeFragment" >
         <action
-            android:id="@+id/action_loginTypeFragment_to_loginFragment2"
+            android:id="@+id/action_loginTypeFragment_to_loginFragment"
             app:destination="@id/loginFragment" />
         <action
-            android:id="@+id/action_loginTypeFragment_to_userRegistrationFragment2"
+            android:id="@+id/action_loginTypeFragment_to_userRegistrationFragment"
             app:destination="@id/userRegistrationFragment" />
     </fragment>
     <fragment
         android:id="@+id/loginFragment"
         android:name="com.fakedevelopers.bidderbidder.ui.login.LoginFragment"
         android:label="fragment_login"
-        tools:layout="@layout/fragment_login" />
+        tools:layout="@layout/fragment_login" >
+        <action
+            android:id="@+id/action_loginFragment_to_userRegistrationFragment"
+            app:destination="@id/userRegistrationFragment" />
+    </fragment>
     <fragment
         android:id="@+id/userRegistrationFragment"
         android:name="com.fakedevelopers.bidderbidder.ui.register.UserRegistrationFragment"

--- a/app/src/main/res/navigation/login_graph.xml
+++ b/app/src/main/res/navigation/login_graph.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/login_graph"
+    app:startDestination="@id/loginTypeFragment">
+
+    <fragment
+        android:id="@+id/loginTypeFragment"
+        android:name="com.fakedevelopers.bidderbidder.ui.loginType.LoginTypeFragment"
+        android:label="LoginTypeFragment" >
+        <action
+            android:id="@+id/action_loginTypeFragment_to_loginFragment2"
+            app:destination="@id/loginFragment" />
+        <action
+            android:id="@+id/action_loginTypeFragment_to_userRegistrationFragment2"
+            app:destination="@id/userRegistrationFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/loginFragment"
+        android:name="com.fakedevelopers.bidderbidder.ui.login.LoginFragment"
+        android:label="fragment_login"
+        tools:layout="@layout/fragment_login" />
+    <fragment
+        android:id="@+id/userRegistrationFragment"
+        android:name="com.fakedevelopers.bidderbidder.ui.register.UserRegistrationFragment"
+        android:label="UserRegistrationFragment" />
+</navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -49,6 +49,7 @@
             app:destination="@id/productSearchFragment" />
         <argument
             android:name="searchWord"
+            android:defaultValue=""
             app:argType="string" />
         <action
             android:id="@+id/action_productListFragment_self"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,38 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/loginTypeFragment">
+    app:startDestination="@id/productListFragment">
 
-    <fragment
-        android:id="@+id/loginTypeFragment"
-        android:name="com.fakedevelopers.bidderbidder.ui.loginType.LoginTypeFragment"
-        android:label="fragment_login_type"
-        tools:layout="@layout/fragment_login_type" >
-        <action
-            android:id="@+id/action_loginTypeFragment_to_loginFragment"
-            app:destination="@id/loginFragment" />
-        <action
-            android:id="@+id/action_loginTypeFragment_to_userRegistrationFragment"
-            app:destination="@id/userRegistrationFragment" />
-        <action
-            android:id="@+id/action_loginTypeFragment_to_productListFragment"
-            app:destination="@id/productListFragment"
-            app:popUpTo="@id/nav_graph"
-            app:popUpToInclusive="true" />
-    </fragment>
-    <fragment
-        android:id="@+id/loginFragment"
-        android:name="com.fakedevelopers.bidderbidder.ui.login.LoginFragment"
-        android:label="LoginFragment" >
-        <action
-            android:id="@+id/action_loginFragment_to_mainFragment"
-            app:destination="@id/productListFragment"
-            app:popUpTo="@id/nav_graph"
-            app:popUpToInclusive="true" />
-        <action
-            android:id="@+id/action_loginFragment_to_userRegistrationFragment"
-            app:destination="@id/userRegistrationFragment" />
-    </fragment>
     <fragment
         android:id="@+id/productListFragment"
         android:name="com.fakedevelopers.bidderbidder.ui.productList.ProductListFragment"
@@ -109,16 +79,6 @@
             android:name="searchWord"
             app:argType="string"
             android:defaultValue="" />
-    </fragment>
-    <fragment
-        android:id="@+id/userRegistrationFragment"
-        android:name="com.fakedevelopers.bidderbidder.ui.register.UserRegistrationFragment"
-        android:label="UserRegistrationFragment" >
-        <action
-            android:id="@+id/action_userRegistrationFragment_to_productListFragment"
-            app:destination="@id/productListFragment"
-            app:popUpTo="@id/nav_graph"
-            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/productDetailFragment"


### PR DESCRIPTION
### 개요
* 로그인 / 메인 액티비티 분리

### 변경사항
* LoginActivity 추가
  * LoginFragment, LoginTypeFragment, UserRegistrationFragment를 LoginActivity에서 관리합니다.
* 네비게이션 그래프 분리
* Hilt 모듈 분리

### 관련 지라 및 위키 링크
* [BDBD-503](https://fake-developers.atlassian.net/browse/BDBD-503?atlOrigin=eyJpIjoiMGMyMWJkZTY2MzI2NDMxNzg2YTQ0MTkwMGM0ZWFmOWIiLCJwIjoiaiJ9)
* [Dagger Hilt로 안드로이드 의존성 주입 시작하기](https://hyperconnect.github.io/2020/07/28/android-dagger-hilt.html)

### 분리로 얻는 효능
* 네비게이션 그래프 복잡도 감소
* 로그인 화면이 가벼워짐
  * MainActivity에 박혀있는 Listener들은 로그인 화면에선 쓸모없음
  * 아무것도 정의하지 않은 퓨어한 LoginActivity로 옮기면서 Listener에 의한 불필요한 동작을 없앰
* 메모리 절약
  * 기존에는 앱을 켜면 로그인 & 메인에 필요한 모든 Repository들을 Singleton으로 생성하고 시작했음
  * Activity를 분리하면서 LoginActivity에선 로그인에 관련된 객체, MainActivity에선 메인에 관련된 객체만 ActivityScope로 생성하기 때문에 메모리 절약