### PR TITLE
FEAT : BDBD-507 글쓰기 api 유저 토큰 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,9 @@
     package="com.fakedevelopers.bidderbidder">
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/> <!-- Sensitive -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"/>
 
     <application
         android:name=".HiltApplication"

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/MainModule.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/api/di/MainModule.kt
@@ -25,7 +25,7 @@ class MainModule {
     // 게시글 등록 요청
     @ActivityRetainedScoped
     @Provides
-    fun provideUserProductRegistrationService(@NormalRetrofit retrofit: Retrofit): ProductRegistrationService =
+    fun provideUserProductRegistrationService(@AuthRetrofit retrofit: Retrofit): ProductRegistrationService =
         retrofit.create(ProductRegistrationService::class.java)
 
     @ActivityRetainedScoped

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
@@ -217,7 +217,7 @@ class ProductRegistrationFragment : BaseFragment<FragmentProductRegistrationBind
                         findNavController().navigate(R.id.action_productRegistrationFragment_to_productListFragment)
                     } else {
                         binding.includeProductRegistrationToolbar.buttonToolbarRegistration.isEnabled = true
-                        Toast.makeText(requireContext(), "글쓰기에 실패했어요~", Toast.LENGTH_SHORT).show()
+                        sendSnackBar("글쓰기에 실패했어요~")
                     }
                 }
             }
@@ -278,9 +278,9 @@ class ProductRegistrationFragment : BaseFragment<FragmentProductRegistrationBind
     // 희망가 <= 최소 입찰가 인지 검사
     private fun checkPriceCondition(): Boolean {
         val openingBid = viewModel.openingBid.value.replace(IS_NOT_NUMBER.toRegex(), "").toLongOrNull() ?: return false
-        val hopePrice = viewModel.hopePrice.value.replace(IS_NOT_NUMBER.toRegex(), "").toLongOrNull() ?: return false
-        if (openingBid >= hopePrice) {
-            Toast.makeText(requireContext(), "최소 입찰가는 희망 가격보다 작아야 합니다.", Toast.LENGTH_SHORT).show()
+        val hopePrice = viewModel.hopePrice.value.replace(IS_NOT_NUMBER.toRegex(), "").toLongOrNull()
+        if (hopePrice != null && hopePrice <= openingBid) {
+            sendSnackBar(getString(R.string.product_registration_error_minimum_bid))
             return false
         }
         return true

--- a/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
+++ b/app/src/main/kotlin/com/fakedevelopers/bidderbidder/ui/productRegistration/ProductRegistrationFragment.kt
@@ -360,6 +360,6 @@ class ProductRegistrationFragment : BaseFragment<FragmentProductRegistrationBind
     }
 
     companion object {
-        private const val COMPRESS_QUALITY = 80
+        private const val COMPRESS_QUALITY = 70
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="product_registration_album_image">앨범 이미지</string>
     <string name="product_registration_selected_image">선택한 이미지</string>
     <string name="product_registration_represent_image">대 표</string>
+    <string name="product_registration_error_minimum_bid">"최소 입찰가는 희망 가격보다 작아야 합니다."</string>
     <!-- Strings related to album list -->
     <string name="album_selected_button_complete">완료</string>
     <string name="album_selected_error_image">불러올 수 없는 이미지 입니다.</string>


### PR DESCRIPTION
### 개요
* 글쓰기 api 유저 토큰 추가

### 변경사항
* 글쓰기 api 유저 토큰 추가 (Retrofit 객체를 바꿨읍니다.)
* 글쓰기 요청 시 등록된 사진 압축 (70%)
  * 용량이 큰 사진을 보내는데 너-무 오래걸려서 압축 해서 보냅니다.
* 희망가를 넣지 않으면 글쓰기가 안됐던! 문제 수정
* api 33에서 미디어 권한을 받을 수 없던 문제 수정
  * 이제 채신폰에도 앨범 화면이 잘 떠요

### 관련 지라 및 위키 링크
* [BDBD-507](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-507)

### 리뷰어에게 하고 싶은 말
비트맵 압축 = 친환경