### PR TITLE
FEAT : BDBD-535  AlbumListViewModel의 의존성 주입을 AssistedInject로 변경

### DIFF
--- a/presentation/src/main/java/com/fakedevelopers/presentation/ui/productEditor/albumList/AlbumListFragment.kt
+++ b/presentation/src/main/java/com/fakedevelopers/presentation/ui/productEditor/albumList/AlbumListFragment.kt
@@ -9,6 +9,8 @@ import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -20,13 +22,24 @@ import com.fakedevelopers.presentation.ui.productEditor.DragAndDropCallback
 import com.fakedevelopers.presentation.ui.util.repeatOnStarted
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class AlbumListFragment : BaseFragment<FragmentAlbumListBinding>(
     R.layout.fragment_album_list
 ) {
 
-    private val viewModel: AlbumListViewModel by viewModels()
+    @Inject
+    lateinit var viewModelFactory: AlbumListViewModel.PathAssistedFactory
+
+    private val viewModel by viewModels<AlbumListViewModel> {
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return viewModelFactory.create(args.albumPath) as T
+            }
+        }
+    }
+
     private val args: AlbumListFragmentArgs by navArgs()
 
     private val backPressedCallback by lazy {

--- a/presentation/src/main/java/com/fakedevelopers/presentation/ui/productEditor/albumList/AlbumListViewModel.kt
+++ b/presentation/src/main/java/com/fakedevelopers/presentation/ui/productEditor/albumList/AlbumListViewModel.kt
@@ -1,6 +1,5 @@
 package com.fakedevelopers.presentation.ui.productEditor.albumList
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fakedevelopers.domain.model.AlbumItem
@@ -13,22 +12,22 @@ import com.fakedevelopers.presentation.ui.productEditor.SelectedPictureListAdapt
 import com.fakedevelopers.presentation.ui.util.MutableEventFlow
 import com.fakedevelopers.presentation.ui.util.ROTATE_DEGREE
 import com.fakedevelopers.presentation.ui.util.asEventFlow
-import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.util.Collections
-import javax.inject.Inject
 import kotlin.math.roundToInt
 
-@HiltViewModel
-class AlbumListViewModel @Inject constructor(
-    args: SavedStateHandle,
+class AlbumListViewModel @AssistedInject constructor(
     isValidUriUseCase: IsValidUriUseCase,
     private val getDateModifiedFromUriUseCase: GetDateModifiedByUriUseCase,
     private val getValidUrisUseCase: GetValidUrisUseCase,
     private val getImagesUseCase: GetImagesUseCase,
-    private val getImageObserverUseCase: GetImageObserverUseCase
+    private val getImageObserverUseCase: GetImageObserverUseCase,
+    @Assisted private val path: String
 ) : ViewModel() {
     private val _albumViewMode = MutableStateFlow(AlbumViewState.GRID)
     val albumViewMode: StateFlow<AlbumViewState> get() = _albumViewMode
@@ -51,8 +50,12 @@ class AlbumListViewModel @Inject constructor(
     var currentViewPagerIdx = 0
         private set
 
-    private val path = args.get<String>("albumPath") ?: ""
     val title = path.substringAfterLast('/')
+
+    @AssistedFactory
+    interface PathAssistedFactory {
+        fun create(path: String): AlbumListViewModel
+    }
 
     init {
         viewModelScope.launch {


### PR DESCRIPTION
### 개요
*  AlbumListViewModel의 의존성 주입을 AssistedInject로 변경

### 변경사항
*  AlbumListViewModel의 의존성 주입을 AssistedInject로 변경

### 관련 지라 및 위키 링크
* [BDBD-535](https://fake-developers.atlassian.net/jira/software/projects/BDBD/boards/10?selectedIssue=BDBD-535)
* [AssistedInject](https://medium.com/@saqwzx88/dagger-hilt-assistedinject-%EB%9F%B0%ED%83%80%EC%9E%84-%EC%A3%BC%EC%9E%85%ED%95%98%EA%B8%B0-871c15d952bf)

### 리뷰어에게 하고 싶은 말
* _Hilt를 사용해 생성자 주입을 할 때 주입 변수와 일반 변수가 동시에 있으면 어떻게 할까요?_

면접에서 이런 질문을 받았지만 바보였던 저는 대답을 할 수가 없었습니다.
이제는 확실히 말할 수 있읍니다. 고것은 AssistedInject를 활용하면 되는 것이라고..

[BDBD-535]: https://fake-developers.atlassian.net/browse/BDBD-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ